### PR TITLE
Make package reproducible on arch linux

### DIFF
--- a/configure
+++ b/configure
@@ -7060,7 +7060,7 @@ case "$cf_item" in
 	;;
 (gzip)
 	cf_manpage_so_strip="gz"
-	cf_manpage_compress=gzip
+	cf_manpage_compress="gzip -n"
 	;;
 (bzip2)
 	cf_manpage_so_strip="bz2"


### PR DESCRIPTION
Currently this package is not fully reproducible on arch linux. See the [diffoscope](https://reproducible.archlinux.org/api/v0/builds/584646/diffoscope).
The issue is the recorded timestamp in the gzip header which can easily be ignored with the [no-name](https://wiki.debian.org/ReproducibleBuilds/TimestampsInGzipHeaders) flag for gzip.